### PR TITLE
Added unit test runner and simple test harness for Cardinal Care enco…

### DIFF
--- a/claims_analysis/cardinal_care/cardinal_care.html
+++ b/claims_analysis/cardinal_care/cardinal_care.html
@@ -187,6 +187,8 @@
 
   <script src="../../src/load_common_data.js"></script>
   <script src="../../src/epilog.js"></script>
+  <script src="../../src/test_running.js"></script>
+  <script src="test_harness_cardinal_care.js"></script>
   <script src="cardinal_care.js"></script>
 </body>
 </html>

--- a/claims_analysis/cardinal_care/test_harness_cardinal_care.js
+++ b/claims_analysis/cardinal_care/test_harness_cardinal_care.js
@@ -1,0 +1,31 @@
+// Adds an event listener instead of setting onload, so that it doesn't get overwritten 
+window.addEventListener("load", function() {
+
+    let accumulated_test_results = [];
+
+    console.log("============ BEGIN CARDINAL CARE TESTS ============");
+    
+    let ruleset = definemorerules([], readdata('q(X) :- p(X)'));
+    
+    // ================ Example test 1 ================
+    let test_name = "Example Test 1";
+    accumulated_test_results.push([test_name, run_unit_test(test_name, 'X', 'q(X)', ['b', 'a'], 'p(a) p(b)', ruleset, true)]); // Prints the verbose output
+    
+    // ================ Example test 2 ================
+    test_name = "Example Test 2";
+    accumulated_test_results.push([test_name, run_unit_test(test_name, 'X', 'q(X)', ['b'], 'p(a) p(b)', ruleset, true)]); // Prints the verbose output
+
+    // ==================== Aggregate results ====================
+    let num_succeeded_tests = accumulated_test_results.filter(function(result_pair) {return result_pair[1]}).length;
+    let failed_tests = accumulated_test_results.filter(function(result_pair) {return !result_pair[1]})
+
+    console.log("======= CARDINAL CARE TEST RESULTS SUMMARY =======");
+    console.log(num_succeeded_tests + " out of " + accumulated_test_results.length + " tests succeeded." );
+
+    console.log("=== FAILING TESTS ===");
+    for (let [failed_test_name, _] of failed_tests) {
+        console.log(failed_test_name);
+    }
+
+    console.log("============ END CARDINAL CARE TESTS ============");
+  });

--- a/src/test_running.js
+++ b/src/test_running.js
@@ -1,0 +1,41 @@
+// Depends on epilog.js
+
+// Returns true if the query run on the dataset (induced by dataset_str) and ruleset produces exactly the results in expected_result_list (ignoring order)
+    // and false otherwise
+
+function run_unit_test(test_name, variable_expr, query_str, expected_result_list, dataset_str, ruleset, verbose = false) {
+    let query = read(query_str);
+    let dataset = definemorefacts([], readdata(dataset_str));
+
+    let results = compfinds(variable_expr, query, dataset, ruleset);
+
+    let expected_result_set = new Set(expected_result_list);
+
+    if (verbose) {
+        console.log("====== Verbose Output for test:", test_name, "======");
+        console.log("variable_expr:", variable_expr);
+        console.log("query_str:", query_str);
+        console.log("dataset_str:", dataset_str);
+        console.log("dataset generated from dataset_str:", grindem(dataset));
+        console.log("ruleset:", ruleset);
+        console.log("expected_result_list:", expected_result_list);
+        console.log("RESULTS:", results);
+    }
+
+    for (let result of results) {
+        if (!expected_result_set.has(result)) {
+            console.error("===== TEST FAILED: " + test_name + "===== ");
+            return false;
+        }
+    }
+    
+    console.log("===== TEST SUCCEEDED: " + test_name + "===== ");
+    return true;
+}
+
+
+/* Example usage:
+    let ruleset = definemorerules([], readdata('q(X) :- p(X)'));
+
+    console.log(run_unit_test("Example Test", 'X', 'q(X)', ['b', 'a'], 'p(a) p(b)', ruleset, true)); // Prints 'true', in addition to the verbose output
+*/


### PR DESCRIPTION
…ding

- Created test_running.js for the function "run_unit_test", which runs a single query test on a dataset and ruleset. Documentation and example found in the file and in test_harness_cardinal_care.js.
- Created "test_harness_cardinal_care.js", a simple test harness for running unit tests of the Cardinal Care encoding. Computes and prints the number of succeeding tests, and prints the names of the tests that failed.
- Import these files into cardinal_care.html to run the tests on page load and print the results to console.